### PR TITLE
Initial commit: add uncommented test to see about test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           name: Running tests
           command: |
             . venv/bin/activate
-            python3 manage.py test
+            pytest
       - store_artifacts:
           path: test-reports/
           destination: python_app

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,10 +20,12 @@ google-auth==2.18.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==1.0.0
 googleapis-common-protos==1.59.0
+greenlet==2.0.2
 gunicorn==20.1.0
 httplib2==0.22.0
 idna==3.4
 iniconfig==2.0.0
+install==1.3.5
 isort==5.12.0
 langchain==0.0.168
 lazy-object-proxy==1.9.0
@@ -53,6 +55,7 @@ pydocstyle==6.3.0
 pyflakes==3.0.1
 pyparsing==3.0.9
 pytest==7.3.1
+pytest-cov==4.0.0
 pytest-django==4.5.2
 python-dateutil==2.8.2
 python-decouple==3.8
@@ -60,6 +63,7 @@ pytz==2023.3
 PyYAML==6.0
 regex==2023.5.5
 requests==2.29.0
+requests-mock==1.10.0
 requests-oauthlib==1.3.1
 rsa==4.9
 six==1.16.0
@@ -75,5 +79,6 @@ typing_extensions==4.5.0
 tzdata==2023.3
 uritemplate==4.1.1
 urllib3==1.26.15
+vcrpy==4.2.1
 wrapt==1.15.0
 yarl==1.9.2

--- a/tldr_app/models.py
+++ b/tldr_app/models.py
@@ -26,3 +26,11 @@ class Result(models.Model):
 		def clean(self):
 			if not self.response or not self.query:
 				raise ValidationError(_('All fields must be filled in.'))
+			
+# class false(models.Model):
+#     response = models.TextField()
+#     query = models.ForeignKey(Query, on_delete=models.CASCADE)
+    
+#     def clean(self):
+#       if not self.response or not self.query:
+#         raise ValidationError(_('All fields must be filled in.'))

--- a/tldr_app/tests/test_queries_api_calls.py
+++ b/tldr_app/tests/test_queries_api_calls.py
@@ -1,4 +1,4 @@
-# import pytest
+import pytest
 import requests
 import json
 # import requests_mock


### PR DESCRIPTION
# Checklist:

- I have performed a self-review of my own code,
- I have added tests that prove my fix is effective or that my feature works,

Resolves #024 and Resolves #027

### Description
Further testing into coverage has shown that in order to see coverage based off of tests, the command you would want to run is this:
```coverage run --source='tldr_app' -m pytest tldr_app/tests/*.py```

Also changes circle CI to run off of pytest and properly run tests as well as have vcr in the venv.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

There is commented out code in ```test_queries_api_calls.py``` that when uncommented will show a different percentage of coverage with the command ```coverage report``` as well as ```coverage html``` followed by ```open htmlcov/index.html```.

Circle CI passes with the new logic.