### PR TITLE
Issue #25 - Format response of /queries endpoint

### DIFF
--- a/tldr_app/serializers.py
+++ b/tldr_app/serializers.py
@@ -15,7 +15,11 @@ class QuerySerializer(serializers.ModelSerializer):
 				fields = ['id', 'user', 'areas_of_focus', 'tos']
 
 class ResultSerializer(serializers.ModelSerializer):
-		response = serializers.JSONField(required=True)
-		class Meta:
-				model = Result
-				fields = ['response']
+    title = serializers.CharField(source='response.title')
+    impact = serializers.CharField(source='response.impact')
+    actionable = serializers.CharField(source='response.actionable')
+    ranking = serializers.IntegerField(source='response.ranking')
+
+    class Meta:
+        model = Result
+        fields = ['title', 'impact', 'actionable', 'ranking']

--- a/tldr_app/services.py
+++ b/tldr_app/services.py
@@ -16,15 +16,16 @@ class QueryGPT():
 		query_engine = index.as_query_engine()
 		responses = []
 		json_string = """
-      "area_of_focus": {
+      {
+				"title": "areas_of_focus"
         "impact": "key information about how this terms of service would effect me in regards to this area_of_focus.",
         "actionable": "any steps outlined in the terms of service how I, as the consumer can take to protect myself in regards to this area_of_focus.",
         "ranking": "On a scale of 1 to 10, with 1 being the most business friendly and 10 being the most consumer friendly, how does this terms of service compare on the issue of this area_of_focus with that of the industry standard. Do not include complete sentences such as 'on a scale of 1 to 10, this is a 7.' in that case, just respond 7. You need to be succinct."
       }
-    } """
+     """
 		
 		for area_of_focus in query.areas_of_focus:
-			response = query_engine.query(f"I am providing you the terms and services of a company. You are instructed to read these terms of service and to respond to the query I have in regard to the terms of service. My query is: How does this terms of service address {area_of_focus}. Please respond with the information in the format of a json string like this: {json_string} where the key 'area_of_focus' is {area_of_focus}.")
+			response = query_engine.query(f"I am providing you the terms and services of a company. You are instructed to read these terms of service and to respond to the query I have in regard to the terms of service. My query is: How does this terms of service address {area_of_focus}. Please respond with the information in the format of a json string like this: {json_string} where the value 'area_of_focus' is {area_of_focus}.")
 			result = Result(response=json.loads(str(response)), query=query)
 			result.save()
 			responses.append(result)

--- a/tldr_app/views.py
+++ b/tldr_app/views.py
@@ -38,7 +38,6 @@ class QueryApiView(APIView):
 		return Response(serializer.data, status=status.HTTP_200_OK)
 							
 	def post(self, request, *args, **kwargs):
-		# import pdb; pdb.set_trace()
 		query_serializer = QuerySerializer(data=request.data)
 		if query_serializer.is_valid():
 			query = query_serializer.save()      


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #25 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Requested response from FE team.
This allows all keys to stay static in response and the values to dynamically change according to user request.
- Change was made to the json_string sample given to ChatGPT.
- Change was made to the ResultSerializer to parse through data and now giving different fields when responding.

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
Postman Response Sample:
![image](https://user-images.githubusercontent.com/115383288/239413599-c42b0c80-02e8-45ad-bff7-b45b66885458.png)