### PR TITLE
Circleci vcr reset

### DIFF
--- a/fixtures/vcr_cassettes/synopsis.yaml
+++ b/fixtures/vcr_cassettes/synopsis.yaml
@@ -26,26 +26,26 @@ interactions:
         to court and must instead resolve any disputes through arbitration.","actionable":"The
         user can opt out of the arbitration clause by sending a written notice to
         Netflix within 30 days of agreeing to the terms of service.","ranking":5},{"title":"recurring
-        payments","impact":"Netflix''s terms of service allow for recurring payments,
-        and members are required to provide payment information to Netflix in order
-        to access the service. Members are also required to keep their payment information
-        up to date.","actionable":"Members can cancel their subscription at any time,
-        and can update their payment information at any time.","ranking":8}]}'
+        payments","impact":"Netflix''s terms of service outlines that members will
+        be charged a recurring fee for their subscription service. The terms of service
+        also outlines that members can cancel their subscription at any time.","actionable":"Members
+        can cancel their subscription at any time by visiting their account page and
+        selecting the cancel subscription option.","ranking":8}]}'
     headers:
       Allow:
       - GET, POST, HEAD, OPTIONS
       Content-Length:
-      - '862'
+      - '860'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 19 May 2023 17:28:39 GMT
+      - Sun, 21 May 2023 00:22:55 GMT
       Referrer-Policy:
       - same-origin
       Server:
-      - WSGIServer/0.2 CPython/3.10.10
+      - WSGIServer/0.2 CPython/3.11.3
       Vary:
       - Cookie, origin
       X-Content-Type-Options:

--- a/tldr_app/tests/test_views.py
+++ b/tldr_app/tests/test_views.py
@@ -85,7 +85,7 @@ def test_post_request_make_query():
 def test_post_individual_unit_test(db):
     user = User.objects.create(name="Hady")
     query = Query.objects.create(user=user, tos="test", areas_of_focus=["payment", "subscription"])
-    result = Result.objects.create(query=query, response="This is a test response")
+    result = Result.objects.create(query=query, response={"title": "Test title", "impact": "Test impact", "actionable": "Test actionable", "ranking": 1})
     
     factory = RequestFactory()
     request = factory.post('/fake-url/', data= {"areas_of_focus": ["area", "focus"], "tos" :"sample TOS", "user": user.id}) 

--- a/tldr_app/tests/test_views.py
+++ b/tldr_app/tests/test_views.py
@@ -54,7 +54,7 @@ def test_get_all_queries(db):
 
 # NEXT IS TO TEST MAKING A QUERY 
 
-POST_URL = 'http://localhost:8000/api/queries'
+POST_URL = 'http://localhost:8000/api/v1/queries'
 
 def test_post_request_make_query():
     payload = {
@@ -70,8 +70,17 @@ def test_post_request_make_query():
       assert response.status_code == 201
       response_data = response.json()
       assert isinstance(response_data, dict)
-      assert isinstance(response_data['response'], str)
-      assert isinstance(response_data['id'], int)
+      assert isinstance(response_data['data'], list)
+      assert isinstance(response_data['data'][0], dict)
+      assert isinstance(response_data['data'][0]['title'], str)
+      assert isinstance(response_data['data'][0]['impact'], str)
+      assert isinstance(response_data['data'][0]['actionable'], str)
+      assert isinstance(response_data['data'][0]['ranking'], int)
+      assert isinstance(response_data['data'][1], dict)
+      assert isinstance(response_data['data'][1]['title'], str)
+      assert isinstance(response_data['data'][1]['impact'], str)
+      assert isinstance(response_data['data'][1]['actionable'], str)
+      assert isinstance(response_data['data'][1]['ranking'], int)
 
 def test_post_individual_unit_test(db):
     user = User.objects.create(name="Hady")


### PR DESCRIPTION
# Checklist:

- I have performed a self-review of my own code,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),

Resolves #038

### Description
In an attempt to make a new vcr cassette on my local machine to push to hopefully get onto circleCI, I found that the new cassette was getting a 401. Digging further into it, turns out the POST_URL  variable in the test_views on line 57 had the value of ```http://localhost:8000/api/queries```  not ```http://localhost:8000/api/v1/queries``` . 

From there, a number of asserts needed updating too. The tests were running off of old logic. That, and the factory post on line 88 needed to be updated to new logic as well with its response value needing to be a dict with the keys of title, impact, actionable, and ranking. 

Hopefully now with a fresh cassette it will succeed on CircleCI. Will need to check after this is merged, as CircelCI has given false positives before.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

These are changes to tests themselves, and are not a guaranteed fix until we see CircleCI built with no issue.
